### PR TITLE
Using pydantic fields for local process i/o definitions, part 2

### DIFF
--- a/s2gos-server/src/s2gos_server/services/local/process_registry.py
+++ b/s2gos-server/src/s2gos_server/services/local/process_registry.py
@@ -189,7 +189,7 @@ def create_json_schema(
     inline_sep: str | None = ".",
 ) -> dict[str, Any]:
     schema = model_class.model_json_schema(mode="serialization")
-    schema = inline_pydantic_schema_refs(schema)
+    schema = inline_schema_refs(schema)
     if inline_objects and isinstance(schema.get("properties"), dict):
         schema = inline_object_properties(schema, inline_objects, inline_sep)
     return backport_schema_to_openapi_3_0(schema)
@@ -235,22 +235,20 @@ def inline_object_properties(
     return schema
 
 
-def inline_pydantic_schema_refs(schema: dict[str, Any]):
+def inline_schema_refs(schema: dict[str, Any]):
     defs: dict[str, Any] | None = schema.get("$defs")
     if not defs:
         return schema
     schema = copy.copy(schema)
     schema.pop("$defs")
-    return _inline_pydantic_schema_refs(
-        schema, {f"#/$defs/{k}": v for k, v in defs.items()}
-    )
+    return _inline_schema_refs(schema, {f"#/$defs/{k}": v for k, v in defs.items()})
 
 
-def _inline_pydantic_schema_refs(schema: dict[str, Any], defs: dict[str, Any]):
+def _inline_schema_refs(schema: dict[str, Any], defs: dict[str, Any]):
     if "$ref" in schema:
         ref = schema["$ref"]
         if ref in defs:
-            ref_schema = _inline_pydantic_schema_refs(defs[ref], defs)
+            ref_schema = _inline_schema_refs(defs[ref], defs)
             schema = copy.copy(schema)
             schema.pop("$ref")
             schema.update(copy.deepcopy(ref_schema))
@@ -259,19 +257,18 @@ def _inline_pydantic_schema_refs(schema: dict[str, Any], defs: dict[str, Any]):
     for k in ("allOf", "anyOf", "oneOf"):
         if k in schema:
             if isinstance(schema[k], list):
-                schema[k] = [_inline_pydantic_schema_refs(s, defs) for s in schema[k]]
+                schema[k] = [_inline_schema_refs(s, defs) for s in schema[k]]
     for k in ("items", "prefixItems", "additionalProperties"):
         if k in schema:
             if isinstance(schema[k], list):
-                schema[k] = [_inline_pydantic_schema_refs(s, defs) for s in schema[k]]
+                schema[k] = [_inline_schema_refs(s, defs) for s in schema[k]]
             else:
-                schema[k] = _inline_pydantic_schema_refs(schema[k], defs)
+                schema[k] = _inline_schema_refs(schema[k], defs)
     for k in ("properties",):
         if k in schema:
             if isinstance(schema[k], dict):
                 schema[k] = {
-                    k: _inline_pydantic_schema_refs(s, defs)
-                    for k, s in schema[k].items()
+                    k: _inline_schema_refs(s, defs) for k, s in schema[k].items()
                 }
     return schema
 


### PR DESCRIPTION
* Add support for invoking a process with inlined `pydantic.BaseModel` parameters
* More tests

Checklist (strike out non-applicable):

* [ ] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes/features documented in `docs/*`
* [ ] Unit-tests adapted/added for changes/features 
* [ ] Test coverage remains or increases (target 100%)
