### PR TITLE
Ensure non-Python-identifier names can be used as input names

### DIFF
--- a/s2gos-common/src/tests/process/test_pydantic.py
+++ b/s2gos-common/src/tests/process/test_pydantic.py
@@ -1,0 +1,33 @@
+#  Copyright (c) 2025 by ESA DTE-S2GOS team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+
+from unittest import TestCase
+
+import pydantic
+
+
+class PydanticTest(TestCase):
+    """
+    This test case ensures that pydantic behaves as expected
+    by own code in this package
+    """
+
+    def test_field_names_dont_need_to_be_python_identifiers(self):
+        model_class: type[pydantic.BaseModel] = pydantic.create_model(
+            "Pippo", **{"sur-name": str, "max.age": int}
+        )
+        self.assertIsInstance(model_class, type)
+        self.assertTrue(issubclass(model_class, pydantic.BaseModel))
+        self.assertEqual(
+            {"sur-name", "max.age"},
+            set(model_class.model_fields.keys())
+        )
+
+        # noinspection PyArgumentList
+        model_instance = model_class(**{"sur-name": "Bibo", "max.age": 100})
+        self.assertEqual(
+            {'max.age': 100, 'sur-name': 'Bibo'},
+            model_instance.model_dump(mode="json")
+        )
+


### PR DESCRIPTION
This PR ensure that non-Python-identifier names can be used as input names. Added test for evidence. No code changes seem to be required at this time.

Closes #38

Checklist (strike out non-applicable):

* [ ] ~Changes documented in `CHANGES.md`~
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] ~Added docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~Changes/features documented in `docs/*`~
* [ ] ~Unit-tests adapted/added for changes/features~
* [x] Test coverage remains or increases (target 100%)
