### PR TITLE
Tejas morbagal/dockerfile for s2gos server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in version 0.2.0
+
+- Added Docker packaging for `s2gos-server` (`Dockerfile` and build script).
+
+---
+
 ## Changes in version 0.1.0
 
 Added a dedicated editor for objects of type 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,3 +44,28 @@ and improve efficiency of workflows.
 
 - `Sealed Secrets` - allows us to store passwords and keys safely in Kubernetes without
    exposing them in plain text.
+
+## Building the server image
+
+The `s2gos-server` container image is built with the
+[`build-image.sh`](https://github.com/s2gos-dev/s2gos-controller/blob/main/s2gos-server/build-image.sh)
+script, which wraps `docker build` and pins the eozilla packages (`gavicore`,
+`procodile`, `wraptile`) to a given version.
+
+```commandline
+# Build, tagging the image from the s2gos-server version:
+./s2gos-server/build-image.sh
+
+# Build with an explicit tag:
+./s2gos-server/build-image.sh -t dev
+
+# Build and push to the registry:
+./s2gos-server/build-image.sh -t 0.2.0 --push
+
+# Build against a specific eozilla version:
+./s2gos-server/build-image.sh --eozilla-version 0.2.0.dev1
+```
+
+The image repository defaults to `quay.io/s2gos/s2gos-server`; override it with
+`-r`/`--repo` or the `IMAGE_REPO` environment variable. Run
+`./s2gos-server/build-image.sh --help` for the full list of options.

--- a/s2gos-server/Dockerfile
+++ b/s2gos-server/Dockerfile
@@ -1,0 +1,70 @@
+#  Copyright (c) 2025-2026 by ESA DTE-S2GOS team and contributors
+#  Permissions are hereby granted under the terms of the Apache 2.0 License:
+#  https://opensource.org/license/apache-2-0.
+#
+# Image for the S2GOS gateway server (s2gos-server).
+#
+# The eozilla packages (gavicore, procodile, wraptile) are pulled from
+# PyPI, so the build context is just this directory:
+#
+#   docker build -t quay.io/s2gos/s2gos-server:dev s2gos-server/
+#
+# By default the eozilla packages are pinned to the version in EOZILLA_VERSION.
+# Override it to build against another eozilla version:
+#
+#   docker build --build-arg EOZILLA_VERSION=0.2.0.dev1 \
+#     -t quay.io/s2gos/s2gos-server:0.2.0.dev1 s2gos-server/
+#
+# For non-pinned resolution, override the *_SPEC args with bare names. PRE_FLAG
+# then controls whether pre-releases are considered (--pre, the default) or only
+# proper releases (empty):
+#
+#   # Newest proper release only:
+#   docker build \
+#     --build-arg GAVICORE_SPEC=gavicore \
+#     --build-arg PROCODILE_SPEC=procodile \
+#     --build-arg WRAPTILE_SPEC=wraptile \
+#     --build-arg PRE_FLAG= -t quay.io/s2gos/s2gos-server:0.1.2 s2gos-server/
+
+FROM python:3.12-slim AS production
+
+WORKDIR /app
+
+# s2gos-server 0.1.0 does not ship its own Airflow service, so we default to
+# wraptile's generic Airflow service. It needs the Airflow connection details at
+# run time, e.g.:
+#   docker run … s2gos-server run -- wraptile.services.airflow:service \
+#     --airflow-base-url=… --airflow-username=… --airflow-password=…
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    EOZILLA_SERVER_HOST=0.0.0.0 \
+    EOZILLA_SERVER_PORT=8008 \
+    EOZILLA_SERVICE="wraptile.services.airflow:service"
+
+# Eozilla version the packages are pinned to by default (a dev release).
+ARG EOZILLA_VERSION=0.2.0.dev1
+# Eozilla package specs. Default to the pinned EOZILLA_VERSION; override with
+# bare names ("gavicore") for non-pinned resolution, or other "name==X.Y.Z"
+# pins. An explicit "==<dev>" pin installs even without PRE_FLAG.
+ARG GAVICORE_SPEC=gavicore==${EOZILLA_VERSION}
+ARG PROCODILE_SPEC=procodile==${EOZILLA_VERSION}
+ARG WRAPTILE_SPEC=wraptile==${EOZILLA_VERSION}
+# "--pre" accepts pre-releases and proper releases (newest wins); only relevant
+# for bare-name specs. Set empty to restrict those to proper releases only.
+ARG PRE_FLAG=--pre
+
+COPY . /app/s2gos-server
+
+RUN pip install --no-cache-dir --upgrade pip \
+    # Airflow client is only on PyPI and is not a hard dep of s2gos-server.
+    && pip install --no-cache-dir apache-airflow-client==3.0.2 requests \
+    # Install eozilla releases first; PRE_FLAG is scoped to just these packages
+    # so pre-releases of other deps are not pulled in.
+    && pip install --no-cache-dir ${PRE_FLAG} "${GAVICORE_SPEC}" "${PROCODILE_SPEC}" "${WRAPTILE_SPEC}" \
+    # Install s2gos-server itself; its eozilla requirements are already
+    # satisfied by the dev releases above, so pip leaves them in place.
+    && pip install --no-cache-dir /app/s2gos-server
+
+EXPOSE 8008
+
+CMD ["s2gos-server", "run"]

--- a/s2gos-server/README.md
+++ b/s2gos-server/README.md
@@ -1,7 +1,109 @@
 # DTE-S2GOS controller server
 
 The gateway server for the ESA DTE-S2GOS synthetic scene generator service.
+Python gateway server for the ESA DTE-S2GOS synthetic scene generator service.
+
+## Airflow service
+
+Start by running a local Airflow instance with some test DAGs:
+```commandline
+cd s2gos-airflow
+pixi install
+pixi run airflow standalone
+```
+
+Then run the S2GOS gateway server with the local Airflow instance (assuming
+the local Airflow webserver runs on http://localhost:8080):
+
+```commandline
+pixi shell
+s2gos-server run -- wraptile.services.airflow:service --airflow-password=a8e7f4bb230
+```
+
+> **Note:** `s2gos-server` does not ship its own Airflow service yet, so the
+> generic `wraptile.services.airflow:service` is used.
 
 The S2GOS server is basically a branded 
 [Eozilla wraptile server](https://eo-tools.github.io/eozilla/wraptile/).
 
+## API authentication
+
+`s2gos-server` does not authenticate requests to its OGC API itself. In a
+deployment, place the server behind the platform's authentication gateway or
+reverse proxy, which validates client credentials before forwarding requests.
+Configure the client to send the appropriate credentials as described in the
+[authentication guide](../docs/auth.md).
+
+This is separate from the `--airflow-username` and `--airflow-password`
+options below: those credentials authenticate the gateway to Airflow.
+
+The possible options are
+
+* `--airflow-base-url=TEXT`: The base URL of the Airflow web API, defaults to
+  `http://localhost:8080`.
+* `--airflow-username=TEXT`: The Airflow username, defaults to `admin`.
+* `--airflow-password=TEXT`: The Airflow password.
+  For an Airflow installation with the simple Auth manager, use the one from
+  `.airflow/simple_auth_manager_passwords.json.generated`.
+
+### Running against a deployed Airflow
+
+To run the gateway against a live, deployed Airflow instead of a local one,
+point `--airflow-base-url` at the deployed Airflow API and provide the
+credentials. The service authenticates with the username/password to obtain a
+bearer token and refreshes it on expiry, so this assumes Airflow's
+username/password (JWT) login is reachable at that base URL.
+
+```commandline
+s2gos-server run -- wraptile.services.airflow:service \
+    --airflow-base-url=https://airflow.your-domain.example \
+    --airflow-username=admin \
+    --airflow-password="$AIRFLOW_PASSWORD"
+```
+
+Pass the password via an environment variable (as above) rather than inline, so
+it does not end up in your shell history.
+
+### Running with Docker
+
+The server image (`quay.io/s2gos/s2gos-server`) sets
+`EOZILLA_SERVICE=wraptile.services.airflow:service` by default and binds to
+`0.0.0.0:8008`. Provide the Airflow connection details at run time. Options may
+be passed after `--`:
+
+```commandline
+docker run --rm -p 8008:8008 \
+    quay.io/s2gos/s2gos-server:0.2.0.dev1 \
+    s2gos-server run -- wraptile.services.airflow:service \
+      --airflow-base-url=https://airflow.your-domain.example \
+      --airflow-username=admin \
+      --airflow-password="$AIRFLOW_PASSWORD"
+```
+
+Alternatively, supply the whole service specification via the `EOZILLA_SERVICE`
+environment variable and run the default command:
+
+```commandline
+docker run --rm -p 8008:8008 \
+    -e EOZILLA_SERVICE="wraptile.services.airflow:service --airflow-base-url=https://airflow.your-domain.example --airflow-username=admin --airflow-password=${AIRFLOW_PASSWORD}" \
+    quay.io/s2gos/s2gos-server:0.2.0.dev1
+```
+
+Once running, `GET http://localhost:8008/processes` lists the DAGs exposed by
+that Airflow instance.
+
+
+## Local service
+
+Running the S2GOS gateway server with a local service:
+
+```commandline
+pixi shell
+s2gos-server run -- s2gos_server.services.testing:service --processes --max-workers=5
+```
+
+The possible options are
+
+* `--processes` /  `--no-processes`: Whether to use processes or threads, defaults
+  to threads.
+* `--max-workers=INTEGER`: Maximum number of processes or threads, defaults to 3.

--- a/s2gos-server/build-image.sh
+++ b/s2gos-server/build-image.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Build (and optionally push) the s2gos-server image.
+#
+# By default the eozilla packages (gavicore, procodile, wraptile) are pinned
+# to EOZILLA_VERSION.
+#
+# Usage:
+#   ./s2gos-server/build-image.sh                    # build, tag from s2gos-server version
+#   ./s2gos-server/build-image.sh -t dev             # build with an explicit tag
+#   ./s2gos-server/build-image.sh -t 0.1.0 --push    # build and push to the registry
+#
+#   # Build against a specific eozilla version:
+#   ./s2gos-server/build-image.sh --eozilla-version 0.2.0.dev1
+#
+#   # Override a single package spec (e.g. use the newest proper release):
+#   ./s2gos-server/build-image.sh --wraptile wraptile --stable
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+IMAGE_REPO="${IMAGE_REPO:-quay.io/s2gos/s2gos-server}"
+IMAGE_TAG=""
+PUSH=0
+EOZILLA_VERSION="0.2.0.dev1"
+GAVICORE_SPEC=""
+PROCODILE_SPEC=""
+WRAPTILE_SPEC=""
+PRE_FLAG="--pre"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--tag)          IMAGE_TAG="$2"; shift 2 ;;
+    -r|--repo)         IMAGE_REPO="$2"; shift 2 ;;
+    --eozilla-version) EOZILLA_VERSION="$2"; shift 2 ;;
+    --gavicore)        GAVICORE_SPEC="$2"; shift 2 ;;
+    --procodile)       PROCODILE_SPEC="$2"; shift 2 ;;
+    --wraptile)        WRAPTILE_SPEC="$2"; shift 2 ;;
+    --pre)             PRE_FLAG="--pre"; shift ;;
+    --stable|--no-pre) PRE_FLAG=""; shift ;;
+    --push)            PUSH=1; shift ;;
+    -h|--help)         sed -n '2,21p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *)                 echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Default each unset package spec to the pinned eozilla version.
+GAVICORE_SPEC="${GAVICORE_SPEC:-gavicore==${EOZILLA_VERSION}}"
+PROCODILE_SPEC="${PROCODILE_SPEC:-procodile==${EOZILLA_VERSION}}"
+WRAPTILE_SPEC="${WRAPTILE_SPEC:-wraptile==${EOZILLA_VERSION}}"
+
+# Default the tag to the version declared in s2gos-server/pyproject.toml.
+if [[ -z "$IMAGE_TAG" ]]; then
+  IMAGE_TAG="$(grep -m1 '^version = ' "$SCRIPT_DIR/pyproject.toml" | cut -d'"' -f2)"
+fi
+
+IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+echo "Building ${IMAGE} (context: ${SCRIPT_DIR}, eozilla: ${EOZILLA_VERSION})"
+
+docker build \
+  -f "$SCRIPT_DIR/Dockerfile" \
+  --build-arg "GAVICORE_SPEC=${GAVICORE_SPEC}" \
+  --build-arg "PROCODILE_SPEC=${PROCODILE_SPEC}" \
+  --build-arg "WRAPTILE_SPEC=${WRAPTILE_SPEC}" \
+  --build-arg "PRE_FLAG=${PRE_FLAG}" \
+  -t "$IMAGE" \
+  "$SCRIPT_DIR"
+
+echo "Built ${IMAGE}"
+
+if [[ "$PUSH" -eq 1 ]]; then
+  echo "Pushing ${IMAGE}"
+  docker push "$IMAGE"
+fi


### PR DESCRIPTION
  Server deployment                                                                                                                                                                                                                 
  - Add s2gos-server/Dockerfile producing quay.io/s2gos/s2gos-server, defaulting EOZILLA_SERVICE=wraptile.services.airflow:service.                                                                        
  - Add s2gos-server/build-image.sh to build/tag/push the image, with the eozilla packages (gavicore, procodile, wraptile) pinned to a configurable EOZILLA_VERSION  and per-package spec overrides.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
