### PR TITLE
Tejas morbagal/update default client config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Changes in version 0.2.0
+
+- Added Docker packaging for `s2gos-server` (`Dockerfile` and build script).
+- Reworked `s2gos-client` authentication to use refreshable OAuth2 tokens
+  against Keycloak.
+
+---
+
 ## Changes in version 0.1.0
 
 Added a dedicated editor for objects of type 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 - Added Docker packaging for `s2gos-server` (`Dockerfile` and build script).
 - Reworked `s2gos-client` authentication to use refreshable OAuth2 tokens
   against Keycloak.
+- Fixed `create_client()`/`create_async_client()` silently ignoring
+  `S2GOS_*` environment variables (e.g. `S2GOS_TOKEN`, `S2GOS_AUTH_TYPE`,
+  `S2GOS_API_URL`). Configuration was being read via the base `ClientConfig`
+  class (env prefix `EOZILLA_`) instead of `S2GOSConfig` (env prefix
+  `S2GOS_`).
 
 ## Changes in version 0.1.0
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -15,7 +15,7 @@ The `auth_type` setting selects how the client authenticates:
 
 | `auth_type` | How it works | Required settings |
 |-------------|--------------|-------------------|
-| `none`      | No authentication (default). | — |
+| `none`      | No authentication. | — |
 | `login`     | OAuth2 *password grant*: exchange username/password for access and refresh tokens, then send the access token as a bearer. | `auth_url`, `username`, `password` (+ `client_id`, `client_secret` if required) |
 | `token`     | Send a pre-obtained static token. | `token` |
 | `api-key`   | Send an API key in a custom header. | `api_key` |
@@ -53,6 +53,27 @@ Settings are merged from several sources, in increasing order of precedence:
 
 So a value passed in code overrides an environment variable, which overrides
 the config file.
+
+### Default configuration
+
+Out of the box, the client is preconfigured for the hosted S2GOS service and
+its Keycloak realm, so a plain `create_client()` targets that deployment. The
+built-in defaults are:
+
+| Setting | Default |
+|---------|---------|
+| `api_url` | `https://s2gos.wraptile.brockmann-consult.de/` |
+| `auth_type` | `login` |
+| `auth_url` | `https://kc.dev.brockmann-consult.de/realms/eozilla-auth/protocol/openid-connect/token` |
+| `client_id` | `cuiman` |
+| `grant_type` | `password` |
+| `use_bearer` | `true` |
+
+Because `auth_type` defaults to `login`, you still need to supply your
+`username` and `password` (via any of the sources above) for the initial token
+exchange. Override any default by passing it to `create_client`, setting the
+matching `S2GOS_*` environment variable, or storing it in `~/.s2gos-client` —
+for example, point `api_url` / `auth_url` at a different deployment.
 
 ## Connecting to an OAuth2 server
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,197 @@
+# Authentication
+
+The S2GOS client authenticates requests to the S2GOS service (an
+OGC API - Processes server) using standard HTTP mechanisms. There is **no
+provider-specific code**: the client speaks generic OAuth2 / OIDC and HTTP
+auth, so it works with any compliant authorization server: Keycloak, Auth0,
+Azure AD, or a plain token issuer.
+
+This page explains how to configure the client, with a focus on connecting it
+to an **OAuth2 authorization server**.
+
+## Supported authentication types
+
+The `auth_type` setting selects how the client authenticates:
+
+| `auth_type` | How it works | Required settings |
+|-------------|--------------|-------------------|
+| `none`      | No authentication (default). | — |
+| `login`     | OAuth2 *password grant*: exchange username/password for access and refresh tokens, then send the access token as a bearer. | `auth_url`, `username`, `password` (+ `client_id`, `client_secret` if required) |
+| `token`     | Send a pre-obtained static token. | `token` |
+| `api-key`   | Send an API key in a custom header. | `api_key` |
+| `basic`     | HTTP Basic Auth. | `username`, `password` |
+
+For an OAuth2 server you normally use **`login`** (to obtain a token from your
+credentials) or **`token`** (if you already hold an access token).
+
+## Configuration settings
+
+The relevant settings (fields of the client configuration) are:
+
+| Setting | Description |
+|---------|-------------|
+| `api_url` | URL of the S2GOS service (OGC API - Processes). |
+| `auth_type` | One of the types above. |
+| `auth_url` | The OAuth2 **token endpoint** of your authorization server. |
+| `username` / `password` | User credentials for the password grant. |
+| `client_id` / `client_secret` | OAuth2 client credentials. `client_secret` is only needed for *confidential* clients. |
+| `grant_type` | OAuth2 grant type. Defaults to `password`. |
+| `token` | Access token. It may be supplied directly for `auth_type="token"` or retained after a `login`. |
+| `refresh_token` | OAuth2 refresh token retained after a `login` when the authorization server returns one. |
+| `use_bearer` | If `true` (default), the token is sent as `Authorization: Bearer <token>`. If `false`, it is sent in `token_header`. |
+| `token_header` | Header name used when `use_bearer` is `false`. Defaults to `X-Auth-Token`. |
+| `api_key` / `api_key_header` | API key and its header (default `X-API-Key`) for `auth_type="api-key"`. |
+
+### Where settings come from
+
+Settings are merged from several sources, in increasing order of precedence:
+
+1. Built-in defaults.
+2. The configuration file `~/.s2gos-client` (YAML).
+3. Environment variables prefixed with `S2GOS_` (and a local `.env` file).
+4. Values passed directly in Python (`create_client(**settings)`).
+
+So a value passed in code overrides an environment variable, which overrides
+the config file.
+
+## Connecting to an OAuth2 server
+
+### 1. Gather your authorization-server details
+
+You need, from your OAuth2 / OIDC provider:
+
+- the **token endpoint** URL → `auth_url`
+- a **client ID** (and **client secret** if the client is confidential)
+- **user credentials** (username / password)
+
+For a **Keycloak** realm, the token endpoint looks like:
+
+```
+https://<keycloak-host>/realms/<realm>/protocol/openid-connect/token
+```
+
+### 2. Log in from Python
+
+The recommended way to use the password grant is to pass the settings to
+`create_client`. When `auth_type="login"` and no access token is already
+configured, the client performs the token exchange immediately. It then uses
+the resulting access token as a bearer token on every request:
+
+```python
+import os
+from s2gos_client import create_client
+
+client = create_client(
+    api_url="https://s2gos.example/",
+    auth_type="login",
+    auth_url="https://keycloak.example/realms/s2gos/protocol/openid-connect/token",
+    client_id="s2gos-client",
+    client_secret=os.environ["S2GOS_CLIENT_SECRET"],  # omit for public clients
+    username="alice",
+    password=os.environ["S2GOS_PASSWORD"],
+)
+
+# Authenticated calls:
+processes = client.get_processes()
+```
+
+!!! tip "Keep secrets out of source code"
+    Read passwords and client secrets from environment variables (as above)
+    rather than hard-coding them. Never commit credentials to version control.
+
+### What happens under the hood
+
+1. The client sends an OAuth2 *password grant* request to `auth_url`:
+
+    ```
+    POST <auth_url>
+    Content-Type: application/x-www-form-urlencoded
+
+    grant_type=password&username=alice&password=…&client_id=s2gos-client&client_secret=…
+    ```
+
+2. The authorization server responds with a JSON body containing an
+   `access_token` and, when supported, a `refresh_token`.
+
+3. The client retains `auth_type="login"`, the access token, and any refresh
+   token in its in-memory configuration. It sends the access token on every
+   request to the S2GOS service:
+
+    ```
+    Authorization: Bearer <access_token>
+    ```
+
+## Using a static token instead
+
+If you already have an access token (for example, obtained out-of-band from
+your OAuth2 server), skip the login step and provide the token directly:
+
+```python
+from s2gos_client import create_client
+
+client = create_client(
+    api_url="https://s2gos.example/",
+    auth_type="token",
+    token="eyJhbGciOi…",   # your access token
+    use_bearer=True,        # sent as: Authorization: Bearer <token>
+)
+```
+
+You can also persist a static token with the CLI so you do not have to pass it
+each time:
+
+```console
+$ s2gos-client configure --api-url https://s2gos.example/ --auth-type token --token "$S2GOS_TOKEN" --use-bearer
+```
+
+This writes the settings to `~/.s2gos-client`.
+
+## Configuration by environment variables
+
+Any setting can be supplied via an `S2GOS_`-prefixed environment variable (or a
+`.env` file in the working directory). This is convenient for CI or container
+deployments:
+
+```bash
+export S2GOS_API_URL="https://s2gos.example/"
+export S2GOS_AUTH_TYPE="token"
+export S2GOS_TOKEN="eyJhbGciOi…"
+```
+
+```python
+from s2gos_client import create_client
+
+client = create_client()  # settings picked up from the environment
+```
+
+## Configuration file example
+
+The configuration file `~/.s2gos-client` is YAML. A static-token setup looks
+like this:
+
+```yaml
+api_url: https://s2gos.example/
+auth_type: token
+token: eyJhbGciOi…
+use_bearer: true
+```
+
+## Token expiry and refresh
+
+Access tokens issued by OAuth2 servers expire. For `auth_type="login"`, the
+client keeps the authentication type and refresh token after the initial
+password grant. On an HTTP `401 Unauthorized`, it uses the refresh token to
+obtain a new access token and retries the request once.
+
+!!! note
+    Refreshed tokens are retained only by the client instance; they are not
+    written back to `~/.s2gos-client`. A static `auth_type="token"` setup has
+    no refresh token, so provide a new token when it expires.
+
+## Security notes
+
+- Never commit passwords, client secrets, or tokens to version control.
+- Prefer environment variables or a protected `~/.s2gos-client` file for
+  storing credentials; restrict its file permissions (`chmod 600`).
+- Always use `https://` URLs for both `api_url` and `auth_url` so credentials
+  and tokens are not sent in clear text.

--- a/s2gos-client/src/s2gos_client/api.py
+++ b/s2gos-client/src/s2gos_client/api.py
@@ -40,7 +40,7 @@ def _create_config(**config_overrides: Any) -> ClientConfig:
     Create the S2GOS-specific configuration instance
     from given configuration overrides.
     """
-    config = ClientConfig.create(**config_overrides)
+    config = S2GOSConfig.create(**config_overrides)
     if config.auth_type != "login":
         return config
 

--- a/s2gos-client/src/s2gos_client/api.py
+++ b/s2gos-client/src/s2gos_client/api.py
@@ -23,7 +23,7 @@ _CONFIG_BASE = S2GOSConfig(
     auth_type="login",
     auth_url=(
         "https://kc.dev.brockmann-consult.de/realms/eozilla-auth/protocol"
-        "/openiconnect/token"
+        "/openid-connect/token"
     ),
     client_id="cuiman",
     grant_type="password",

--- a/s2gos-client/src/s2gos_client/api.py
+++ b/s2gos-client/src/s2gos_client/api.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from cuiman.api import AsyncClient, Client, ClientConfig, ClientError
-from cuiman.api.auth import login
+from cuiman.api.auth import login_for_tokens
 from pydantic_settings import SettingsConfigDict
 
 
@@ -19,9 +19,15 @@ class S2GOSConfig(ClientConfig):
 
 
 _CONFIG_BASE = S2GOSConfig(
-    api_url="http://localhost:8008/",
-    auth_url=None,
-    auth_type="none",
+    api_url="https://s2gos.wraptile.brockmann-consult.de/",
+    auth_type="login",
+    auth_url=(
+        "https://kc.dev.brockmann-consult.de/realms/eozilla-auth/protocol"
+        "/openiconnect/token"
+    ),
+    client_id="cuiman",
+    grant_type="password",
+    use_bearer=True,
 )
 _DEBUG = False
 
@@ -34,18 +40,18 @@ def _create_config(**config_overrides: Any) -> ClientConfig:
     Create the S2GOS-specific configuration instance
     from given configuration overrides.
     """
-    # ClientConfig.create() will ready any previous configuration from
-    # ~/.s2gos-client written by command "s2gos-client configure":
     config = ClientConfig.create(**config_overrides)
     if config.auth_type != "login":
-        # already logged in
         return config
 
-    # Login to get an (initial) access token and change auth_type to "token":
-    token = login(config)
-    config_dict = config.to_dict()
-    config_dict.update(auth_type="token", token=token)
-    return S2GOSConfig(**config_dict)
+    # Always obtain fresh tokens: a token read from persistent configuration is
+    # likely expired, and so is its refresh token. Authentication stays of type
+    # "login", which lets the underlying transport refresh the access token
+    # after a 401 response.
+    result = login_for_tokens(config)
+    config.token = result.access_token
+    config.refresh_token = result.refresh_token
+    return config
 
 
 def create_client(**config: Any) -> Client:

--- a/s2gos-client/tests/test_api.py
+++ b/s2gos-client/tests/test_api.py
@@ -5,6 +5,7 @@
 from unittest.mock import Mock, patch
 
 import s2gos_client.api
+from cuiman.api.auth import LoginResult
 
 
 def test_api_exports_ok():
@@ -47,3 +48,56 @@ def test_create_async_client():
     create_config.assert_called_once_with(api_url="https://example.test")
     client_type.assert_called_once_with(config=config, _debug=False)
     assert client is client_type.return_value
+
+
+def test_create_config_logs_in_and_retains_refresh_token():
+    config = Mock(auth_type="login", token=None)
+    login_result = LoginResult(
+        access_token="access-token",
+        refresh_token="refresh-token",
+    )
+
+    with (
+        patch.object(
+            s2gos_client.api.ClientConfig, "create", return_value=config
+        ) as create_config,
+        patch.object(
+            s2gos_client.api, "login_for_tokens", return_value=login_result
+        ) as login,
+    ):
+        created_config = s2gos_client.api._create_config(api_url="https://example.test")
+
+    create_config.assert_called_once_with(api_url="https://example.test")
+    login.assert_called_once_with(config)
+    assert created_config is config
+    assert config.auth_type == "login"
+    assert config.token == "access-token"
+    assert config.refresh_token == "refresh-token"
+
+
+def test_create_config_replaces_persisted_login_token():
+    config = Mock(
+        auth_type="login",
+        token="old-access-token",
+        refresh_token="old-refresh-token",
+    )
+    login_result = LoginResult(
+        access_token="access-token",
+        refresh_token="refresh-token",
+    )
+
+    with (
+        patch.object(
+            s2gos_client.api.ClientConfig, "create", return_value=config
+        ) as create_config,
+        patch.object(
+            s2gos_client.api, "login_for_tokens", return_value=login_result
+        ) as login,
+    ):
+        created_config = s2gos_client.api._create_config(api_url="https://example.test")
+
+    create_config.assert_called_once_with(api_url="https://example.test")
+    login.assert_called_once_with(config)
+    assert created_config is config
+    assert config.token == "access-token"
+    assert config.refresh_token == "refresh-token"


### PR DESCRIPTION
Depends on PR #75 that needs to merged first!

- Configured defaults and refreshable OAuth2 auth for s2gos-client against Keycloak

- In the new flow, the client keeps the refresh_token and stays in "login" mode. That's the mode the underlying transport recognizes as "refreshable": when a request comes back 401, the transport uses the refresh token to obtain
a fresh access token and retries, transparently. Long-running sessions (notebooks, batch jobs) no longer break every few minutes.

- This is in assumption that eozilla-app will support auth type "login".



Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
